### PR TITLE
Add npm start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ npm create vue@latest<br>
 <strong><p>3、进入项目目录(安装依赖)</p></strong>
 npm install
 
+<strong><p>4、一键启动项目</p></strong>
+npm start
+
 
 
 授权逻辑：根据在菜单管理页面配置的权限如权限erp:wh:shelf:add 则可以在组件中加入如下类容,v-hasPerm为权限关键子

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "start": "npm run dev"
   },
   "dependencies": {
     "@element-plus/icons-vue": "^2.0.9",


### PR DESCRIPTION
## Summary
- update README with startup instructions
- add `npm start` script for convenient dev server startup

## Testing
- `npm run dev` *(fails: vite not found because dependencies aren't installed)*
- `npm install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684ee6d1cca8832db436c4b5def5f70b