### PR TITLE
Fix server configuration host

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import {
 import vue from '@vitejs/plugin-vue'
 
 // https://vitejs.dev/config/
-const serverurl = "http://localhost:8099";
+const serverurl = "http://127.0.0.1:8099";
 
 export default defineConfig({
 	plugins: [vue({
@@ -55,7 +55,7 @@ export default defineConfig({
 	},
 	server: {
 		port: 8084,
-		host: '0.0.0.0',
+                host: '127.0.0.1',
 		proxy: {
 			'/api': {
 				target: serverurl,


### PR DESCRIPTION
## Summary
- update `serverurl` to use 127.0.0.1
- bind Vite dev server to 127.0.0.1

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684eecdbc1b0832d9b4caf9fa3aa3e4d