### PR TITLE
Update README with prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 <strong><p>此项目由深圳市万墨信息科技有限公司开发，如果有任何疑问请联系开发团队。</p></strong>
 
+<strong><p>Prerequisites</p></strong>
+Node.js v16+ recommended<br>
+
 <strong><p>1、安装node (注意将Bin添加环境变量Path中)</p></strong>
   1>下载node[](https://nodejs.org/en/download/)<br>
   2、安装vue<br>
 npm create vue@latest<br>
 
+<strong><p>Steps</p></strong>
+git clone https://github.com/your/repo.git<br>
+npm install<br>
+npm start<br>
 <strong><p>3、进入项目目录(安装依赖)</p></strong>
 npm install
 


### PR DESCRIPTION
## Summary
- document Node.js v16+ as a prerequisite
- add quick start steps including clone, install and start commands

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f837f7aec832da1b2e7c170a6fc31