### PR TITLE
Fix incorrect shipv2 import paths

### DIFF
--- a/src/views/erp/ship/shipment_handing/shipstep/components/three_deliver.vue
+++ b/src/views/erp/ship/shipment_handing/shipstep/components/three_deliver.vue
@@ -394,7 +394,7 @@
 	import ShipmentOpt from"./shipment_operator.vue"
 	import shipmenthandlingApi from '@/api/erp/ship/shipmenthandlingApi.js';
     import transportationApi from '@/api/erp/ship/transportationApi.js';
-	import shipmenthandlingV2Api from '@/api/erp/shipV2/shipmentPlacementApi.js';
+	import shipmenthandlingV2Api from '@/api/erp/shipv2/shipmentPlacementApi.js';
 	import { useRoute,useRouter } from 'vue-router'
 	import {formatFloat,dateFormat,dateTimesFormat,CheckInputInt,CheckInputFloat,CheckALLFloat} from '@/utils/index.js';
 	import { ElMessage,ElMessageBox } from 'element-plus';

--- a/src/views/erp/shipv2/shipment_handing/shipstep/components/three_deliver.vue
+++ b/src/views/erp/shipv2/shipment_handing/shipstep/components/three_deliver.vue
@@ -332,7 +332,7 @@
 	import {h, ref ,watch,reactive,onMounted,toRefs} from 'vue'
 	import ShipmentOpt from"./shipment_operator.vue"
 	import shipmenthandlingApi from '@/api/erp/ship/shipmenthandlingApi.js';
-	import shipmenthandlingV2Api from '@/api/erp/shipV2/shipmentPlacementApi.js';
+	import shipmenthandlingV2Api from '@/api/erp/shipv2/shipmentPlacementApi.js';
     import transportationApi from '@/api/erp/ship/transportationApi.js';
 	import { useRoute,useRouter } from 'vue-router'
 	import {formatFloat,dateFormat,dateTimesFormat,CheckInputInt,CheckInputFloat,CheckALLFloat} from '@/utils/index.js';


### PR DESCRIPTION
## Summary
- correct import paths for shipmentPlacementApi in ship step components

## Testing
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f8d872d54832daa3652bda3c6cf55